### PR TITLE
"play" spielt WAV Dateien

### DIFF
--- a/FHEM/10_SNIPS.pm
+++ b/FHEM/10_SNIPS.pm
@@ -993,13 +993,20 @@ sub textCommand($$) {
 sub playBytes($$){
     my ($hash, $cmd) = @_;
     my $ifilename = $cmd;
+    my $siteId = "default";
+    my($unnamedParams, $namedParams) = parseParams($cmd);
+    if (defined($namedParams->{'siteId'}) && defined($namedParams->{'file'})) {
+        $siteId = $namedParams->{'siteId'};
+        $ifilename = $namedParams->{'file'};
+    }
+
     open my $ifile, '<', $ifilename or die "could not open input file $!";
     binmode $ifile;
 
     # Read the binary data
     $_ = do { local $/; <$ifile> };
 
-    MQTT::send_publish($hash->{IODev}, topic => 'hermes/audioServer/default/playBytes/0', message => $_, qos => 0, retain => "0");
+    MQTT::send_publish($hash->{IODev}, topic => 'hermes/audioServer/'.$siteId.'/playBytes/0', message => $_, qos => 0, retain => "0");
 }
 
 

--- a/FHEM/10_SNIPS.pm
+++ b/FHEM/10_SNIPS.pm
@@ -156,6 +156,10 @@ sub Set($$$@) {
         my $text = join (" ", @values);
         SNIPS::say($hash, $text);
     }
+    elsif ($command eq "play") {
+        my $text = join (" ", @values);
+        SNIPS::playBytes($hash, $text);
+    }
     # TextCommand Cmd
     elsif ($command eq "textCommand") {
         my $text = join (" ", @values);
@@ -984,6 +988,18 @@ sub textCommand($$) {
     # Send fake command, so it's forwarded to NLU
     my $topic = "hermes/intent/FHEM:TextCommand";
     onmessage($hash, $topic, $message);
+}
+
+sub playBytes($$){
+    my ($hash, $cmd) = @_;
+    my $ifilename = $cmd;
+    open my $ifile, '<', $ifilename or die "could not open input file $!";
+    binmode $ifile;
+
+    # Read the binary data
+    $_ = do { local $/; <$ifile> };
+
+    MQTT::send_publish($hash->{IODev}, topic => 'hermes/audioServer/default/playBytes/0', message => $_, qos => 0, retain => "0");
 }
 
 


### PR DESCRIPTION
Beispiel: 
`set Snips play /home/pi/alarm.wav`

Grundsätzlich könnte man auch noch ein Konfigurations-Attribut einführen, das festlegt, ob vor der Sprachausgabe immer noch ein Feedback-Sound abgespielt werden soll, damit der User nicht ohne Vorwarnung von Snips angesprochen wird, z.B. bei Remindern oder Alarmen.